### PR TITLE
Minor Pre-Release Fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025
+Copyright (c) 2025 MoReBench
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 MoReBench tests LLMs on 1000 real-world ethical scenarios across diverse domains (healthcare, business, technology, law) and ethical frameworks (consequentialism, deontology, virtue ethics). Unlike current tasks focusing on the outcome accuracy (e.g. math and code), MoReBench evaluates the *quality of moral reasoning* through multi-dimensional rubrics.
 
-[Project Website](https://morebench.github.io/) | [Paper](link) | [Dataset](https://huggingface.co/datasets/morebench/morebench) | [Leaderboard - Coming soon](link) | [UK AISI Inspect Eval - Coming soon](link)
+<p align="center">
+  <a href="https://morebench.github.io/">Project Website</a> | 
+  <a href="link">Paper</a> | 
+  <a href="https://huggingface.co/datasets/morebench/morebench">Dataset</a> | 
+  <a href="link">Leaderboard - Coming soon</a> | 
+  <a href="link">UK AISI Inspect Eval - Coming soon</a>
+</p>
 
 
 ![pipeline](img/intro_pipeline_img.png)
@@ -14,8 +20,16 @@ MoReBench tests LLMs on 1000 real-world ethical scenarios across diverse domains
 ## Quick Start
 
 ```bash
+# Clone the repository
+git clone https://github.com/morebench/morebench.git
+cd morebench
+
+# create a new virtual environment
+conda create -n morebench python=3.12 -y
+conda activate morebench
+
 # Install dependencies
-pip install pandas anthropic openai tqdm numpy datasets
+pip install -r requirements.txt
 
 # 1. Generate model responses
 python run_inferences_on_dilemmas.py \
@@ -145,12 +159,12 @@ python run_best_judge_on_responses_theory.py \
 ```bash
 # Human-readable output
 python calculate_morebench.py \
-    -i model_resp_judgements_private/gpt-4o_reasoning_high_seed_0.jsonl \
+    -i model_resp_judgements/gpt-4o_reasoning_high_seed_0.jsonl \
     -f human
 
 # LaTeX table row (for papers)
 python calculate_morebench.py \
-    -i model_resp_judgements_private/gpt-4o_reasoning_high_seed_0.jsonl \
+    -i model_resp_judgements/gpt-4o_reasoning_high_seed_0.jsonl \
     -f latex
 ```
 
@@ -303,7 +317,7 @@ Same arguments as `calculate_morebench.py`, except default `expected_samples`: 3
 
 ### Judgment Phase
 
-**Format**: `{judgement_type}_judgements_{private|theory}/{filename}`
+**Format**: `{judgement_type}_judgements/{filename}` (`{judgement_type}_judgements_theory` for theory dataset)
 
 ```jsonl
 {
@@ -367,7 +381,7 @@ Score per 1,000 characters (controls for response length bias).
 
 ## License
 
-...
+This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pandas
+anthropic
+openai
+tqdm
+numpy
+datasets

--- a/run_best_judge_on_responses.py
+++ b/run_best_judge_on_responses.py
@@ -1,12 +1,15 @@
 import argparse
-import json
-import random
 import concurrent.futures
-from tqdm import tqdm
+import json
 import os
+import random
 
-from prompts.create_prompts_for_rubric_eval import create_prompt_template_judge_model
-from utils import setup_client, get_judge_response, prepare_criterion_data, load_existing_indices_as_set
+from tqdm import tqdm
+
+from prompts.create_prompts_for_rubric_eval import \
+    create_prompt_template_judge_model
+from utils import (get_judge_response, load_existing_indices_as_set,
+                   prepare_criterion_data, setup_client)
 
 parser = argparse.ArgumentParser(description='Run judge model on generated responses (MoReBench)')
 parser.add_argument("--input_file", "-i", required=True, help="Path to input JSONL file with generations")
@@ -16,7 +19,7 @@ parser.add_argument("--judgement_type", "-jt", default="thinking_trace",
                     help="Which field to judge: model_resp or thinking_trace")
 parser.add_argument("--num_parallel_request", "-n", type=int, default=100, 
                     help="Number of parallel requests")
-parser.add_argument("--debug", "-d", action='store_true', help='Debug with only 10 examples')
+parser.add_argument("--debug", "-d", action='store_true', help='Debug with only 5 examples')
 parser.add_argument("--judge_model", "-jm", default="openai/gpt-oss-120b", 
                     help="Judge model to use (default: openai/gpt-oss-120b)")
 parser.add_argument("--expected_samples", "-es", type=int, default=500,
@@ -50,8 +53,8 @@ with open(args.input_file, "r") as f:
 
 
 if args.debug:
-    data = data[:10]
-    print("DEBUG MODE: Processing only 10 samples")
+    data = data[:5]
+    print("DEBUG MODE: Processing only 5 samples")
 else:
     assert len(data) == args.expected_samples, f"Expected {args.expected_samples} samples but found {len(data)}"
 

--- a/run_best_judge_on_responses_theory.py
+++ b/run_best_judge_on_responses_theory.py
@@ -1,12 +1,15 @@
 import argparse
-import json
-import random
 import concurrent.futures
-from tqdm import tqdm
+import json
 import os
+import random
 
-from prompts.create_prompts_for_rubric_eval import create_prompt_template_judge_model
-from utils import setup_client, get_judge_response, prepare_criterion_data, load_existing_indices_as_set
+from tqdm import tqdm
+
+from prompts.create_prompts_for_rubric_eval import \
+    create_prompt_template_judge_model
+from utils import (get_judge_response, load_existing_indices_as_set,
+                   prepare_criterion_data, setup_client)
 
 parser = argparse.ArgumentParser(description='Run judge model on generated responses (MoReBench-Theory)')
 parser.add_argument("--input_file", "-i", required=True, help="Path to input JSONL file with generations")
@@ -16,7 +19,7 @@ parser.add_argument("--judgement_type", "-jt", default="model_resp",
                     help="Which field to judge: model_resp or thinking_trace")
 parser.add_argument("--num_parallel_request", "-n", type=int, default=160, 
                     help="Number of parallel requests")
-parser.add_argument("--debug", "-d", action='store_true', help='Debug with only 10 examples')
+parser.add_argument("--debug", "-d", action='store_true', help='Debug with only 5 examples')
 parser.add_argument("--judge_model", "-jm", default="openai/gpt-oss-120b", 
                     help="Judge model to use (default: openai/gpt-oss-120b)")
 parser.add_argument("--expected_samples", "-es", type=int, default=150,
@@ -50,8 +53,8 @@ with open(args.input_file, "r") as f:
 
 
 if args.debug:
-    data = data[:10]
-    print("DEBUG MODE: Processing only 10 samples")
+    data = data[:5]
+    print("DEBUG MODE: Processing only 5 samples")
 else:
     assert len(data) == args.expected_samples, f"Expected {args.expected_samples} samples but found {len(data)}"
 

--- a/run_inferences_on_dilemmas.py
+++ b/run_inferences_on_dilemmas.py
@@ -1,17 +1,17 @@
 import argparse
-from ast import literal_eval
 import concurrent.futures
 import os
+from ast import literal_eval
 
 import pandas as pd
-from tqdm import tqdm
 from datasets import load_dataset
+from tqdm import tqdm
 
-from prompts.create_prompts_for_reasoning_eval import create_prompt_template_for_reasoning_eval_natural_behavior
-from utils import (
-    setup_client, get_model_filename, write_to_jsonl, load_existing_indices,
-    collect_response, collect_thinking_response
-)
+from prompts.create_prompts_for_reasoning_eval import \
+    create_prompt_template_for_reasoning_eval_natural_behavior
+from utils import (collect_response, collect_thinking_response,
+                   get_model_filename, load_existing_indices, setup_client,
+                   write_to_jsonl)
 
 parser = argparse.ArgumentParser(description='run inferences on MoReBench dilemmas')
 parser.add_argument("--api_provider", "-ap", required=True, choices=['openai','anthropic','togetherai','xai','openrouter'])
@@ -26,6 +26,7 @@ parser.add_argument("--input_file", "-i", default="dataset_11092025.csv", help="
 parser.add_argument("--reasoning_effort", "-re", default="medium", choices=['minimal','low', 'medium', 'high'])
 parser.add_argument("--seed", "-s", type=int, default=0)
 parser.add_argument("--hf_token","-ht", required=True)
+
 args = parser.parse_args()
 
 # Setup
@@ -65,8 +66,7 @@ def process_single_row(row, idx):
 
 
 # Load data
-# df = pd.read_csv(args.input_file)
-ds = load_dataset("morebench/morebench", token=args.hf_token, data_files="morebench_public.csv", split="test")
+ds = load_dataset("morebench/morebench", token=args.hf_token, data_files="morebench_public.csv", split="train")
 df = ds.to_pandas()
 
 df = df[df['THEORY'] == 'neutral']

--- a/run_inferences_on_dilemmas_theory.py
+++ b/run_inferences_on_dilemmas_theory.py
@@ -1,17 +1,17 @@
 import argparse
-from ast import literal_eval
 import concurrent.futures
 import os
+from ast import literal_eval
 
 import pandas as pd
-from tqdm import tqdm
 from datasets import load_dataset
+from tqdm import tqdm
 
-from prompts.create_prompts_for_reasoning_eval import create_prompt_template_for_reasoning_eval_natural_behavior
-from utils import (
-    setup_client, get_model_filename, write_to_jsonl, load_existing_indices,
-    collect_response, collect_thinking_response
-)
+from prompts.create_prompts_for_reasoning_eval import \
+    create_prompt_template_for_reasoning_eval_natural_behavior
+from utils import (collect_response, collect_thinking_response,
+                   get_model_filename, load_existing_indices, setup_client,
+                   write_to_jsonl)
 
 parser = argparse.ArgumentParser(description='run inferences on MoReBench dilemmas under moral frameworks')
 parser.add_argument("--api_provider", "-ap", required=True, choices=['openai','anthropic','togetherai','xai','openrouter'])
@@ -66,8 +66,7 @@ def process_single_row(row, idx):
 
 
 # Load data
-# df = pd.read_csv(args.input_file)
-ds = load_dataset("morebench/morebench", token=args.hf_token, data_files="morebench_public.csv", split="test")
+ds = load_dataset("morebench/morebench", token=args.hf_token, data_files="morebench_theory.csv", split="train")
 df = ds.to_pandas()
 
 df = df[df['THEORY'] != 'neutral']


### PR DESCRIPTION
- Added MIT Licennce
- Updated README with the following:
  - Centered links
  - Added bash commands to clone the repo and initialize the venv
  - Moved requirements into `requirements.txt`
  - Removed `private` from the instructions
- Made number of debug tasks consistent (5 everywhere)
- Setting dataset loading to "train", given that  the "test" split cannot be found when downloading data from HF